### PR TITLE
Add export-ignore to LFS data files to fix git archive in package builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-data/** filter=lfs diff=lfs merge=lfs -text
+data/** filter=lfs diff=lfs merge=lfs -text export-ignore


### PR DESCRIPTION
Using sensai's repo as a git dependency (i.e. requiring some commit with `pip install git+...` instead of a pypi package) can fail with `tarfile.ReadError: unexpected end of data` in `setuptools_scm`'s git archive call. This can happen randomly e.g. due to transient github errors.

1. `setuptools_scm` runs `git archive` to enumerate source files
2. `git-lfs` intercepts the archive stream to replace LFS pointers with actual content
3. An LFS download fails mid-stream -> truncated tar -> RIP.

This PR provides a solution by excluding the LFS files in the `data/` directory from archives, which has several side-effects:

* git archive: the data files are excluded from the archive stream so that now `pip install git+...` and `uv` installs always work.
* The `sdist` now loses `data`, but `MANIFEST.in` never explicitly included it either, so it's unclear to me what the intent was.
* In particular, GitHub's "Download ZIP" / release source tarballs won't include `data/`. Anyone downloading a zip of the repo won't get the test data.

I'm not sure whether the source distribution issue is a deal breaker for this PR.

OTOH:

* Normal git clone remains unaffected. LFS smudge still works as before for developers.
* `git ls-files` is also unaffected. setuptools' include_package_data uses `ls-files`, not `archive`, so package data discovery is unchanged.
* The `data` dir was never going into the wheel anyway.
* Developers who `git clone` and want to run geoanalytics tests still get the LFS files normally.
* CI uses lfs to pull test files, not sdist, so that will be ok too.
